### PR TITLE
Remove Update Effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,26 +118,6 @@ withEffects(app)({
 
 This same convention follows for all the other effects as well.
 
-### `update`
-
-```js
-update = function(partialState: object): EffectTuple
-```
-
-Describes an effect that will update `state` immediately, useful for combining with effects that will change `state` later.
-
-Example:
-
-```js
-import { withEffects, update } from "hyperapp-effects"
-
-withEffects(app)({
-  actions: {
-    foo: () => update({ processing: true })
-  }
-}).foo()
-```
-
 ### `frame`
 
 ```js

--- a/README.md
+++ b/README.md
@@ -142,6 +142,36 @@ withEffects(app)({
 }).foo()
 ```
 
+If you wish to have an action that continuously updates the `state` and rerenders inside of `requestAnimationFrame` (such as for a game), remember to include another `frame` effect in your return:
+
+```js
+import { withEffects, action, frame } from "hyperapp-effects"
+
+withEffects(app)({
+  state: {
+    time: 0,
+    delta: 0
+  },
+  actions: {
+    init: () => frame("update"),
+    update: () => ({ time }) => [
+      action("incTime", time),
+
+      // ...
+      // Other actions to update the state based on delta time
+      // ...
+
+      // End with a recursive frame effect to perform the next update
+      frame("update")
+    ],
+    incTime: ({ time: lastTime, delta: lastDelta }) => time => ({
+      time: time || lastTime,
+      delta: time && lastTime ? time - lastTime : lastDelta
+    })
+  }
+}).init()
+```
+
 ### `delay`
 
 ```js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperapp-effects",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Effects as data for Hyperapp",
   "main": "dist/effects.js",
   "jsnext:main": "src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -26,9 +26,6 @@ function runIfEffect(actions, maybeEffect) {
       case "action":
         getAction(actions, props.name)(props.data)
         break
-      case "update":
-        actions.update(props.state)
-        break
       case "frame":
         requestAnimationFrame(function(time) {
           props.data.time = time
@@ -83,11 +80,6 @@ export function withEffects(app) {
     }
 
     props.actions = enhanceActions(props.actions)
-    props.actions.update = function(state, actions) {
-      return function(newState) {
-        return newState
-      }
-    }
 
     return app(props)
   }
@@ -101,10 +93,6 @@ export function action(name, data) {
       data: data
     }
   ]
-}
-
-export function update(state) {
-  return ["update", { state: state }]
 }
 
 export function frame(action, data) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,14 +1,5 @@
 import { app } from "hyperapp"
-import {
-  withEffects,
-  action,
-  update,
-  frame,
-  delay,
-  time,
-  log,
-  http
-} from "../src"
+import { withEffects, action, frame, delay, time, log, http } from "../src"
 
 test("without actions", done =>
   withEffects(app)({
@@ -65,27 +56,14 @@ test("fire a slice action", done =>
     }
   }).foo())
 
-test("update with effects", () => {
-  const actions = withEffects(app)({
-    actions: {
-      get: state => state,
-      foo: () => [update({ key: "value" }), update({ some: "other value" })]
-    }
-  })
-  actions.foo()
-  expect(actions.get()).toEqual({
-    key: "value",
-    some: "other value"
-  })
-})
-
-test("mix action and update effects", done =>
+test("state updates with action effects", done =>
   withEffects(app)({
     actions: {
+      update: () => state => state,
       foo: () => [
-        update({ key: "value" }),
+        action("update", { key: "value" }),
         action("bar", { some: "data" }),
-        update({ some: "other value" }),
+        action("update", { some: "other value" }),
         action("baz", { moar: "stuff" })
       ],
       bar: state => data => {


### PR DESCRIPTION
This had the potential to conflict with a user-provided `update` action and the small syntax sugar wasn't worth that potential headache.

You can still manually add your own `update` action and call it with the `action` effect.

Before:

```js
withEffects(app)({
  actions: {
    foo: () => update({ processing: true })
  }
}).foo()
```

After:

```js
withEffects(app)({
  actions: {
    update: () => state => state,
    foo: () => action("update", { processing: true })
  }
}).foo()
```

Not so painful after all is it?