### PR TITLE
Support Effects in View

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,25 @@ withEffects(app)({
 
 This same convention follows for all the other effects as well.
 
+Also note that `action` (and other effects) may be used for props in your `view`. The originally fired event is available as the `event` property on the action `data`:
+
+```js
+import { withEffects, action } from "hyperapp-effects"
+
+withEffects(app)({
+  actions: {
+    foo: () => data => {
+      // data will have { event: { ...eventProps }, message: "hello" }
+    }
+  },
+  view: () => h("button", {
+    onclick: action("foo", { message: "hello" })
+  })
+})
+```
+
+However, it's recommended to only use `action` effects in your `view`, and all other effects from in `actions`.
+
 ### `frame`
 
 ```js

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ withEffects(app)({
 
 This same convention follows for all the other effects as well.
 
-Also note that `action` (and other effects) may be used for props in your `view`. The originally fired event is available as the `event` property on the action `data`:
+Also note that `action` (and other effects) may be used for handler props in your `view`:
 
 ```js
 import { withEffects, action } from "hyperapp-effects"
@@ -126,7 +126,7 @@ import { withEffects, action } from "hyperapp-effects"
 withEffects(app)({
   actions: {
     foo: () => data => {
-      // data will have { event: { ...eventProps }, message: "hello" }
+      // data will have { message: "hello" }
     }
   },
   view: () => h("button", {
@@ -135,33 +135,15 @@ withEffects(app)({
 })
 ```
 
-However, it's recommended to only use `action` effects in your `view`, and all other effects from in `actions`.
-
 ### `frame`
 
 ```js
-frame = function(name: string, data?: object): EffectTuple
+frame = function(name: string): EffectTuple
 ```
 
-Describes an effect that will call an action from inside [`requestAnimationFrame`](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestAnimationFrame), which is also where the render triggered by the action will run, optionally with a `data` object. A relative timestamp will be provided as the `time` property on the action `data`.
+Describes an effect that will call an action from inside [`requestAnimationFrame`](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestAnimationFrame), which is also where the render triggered by the action will run. A relative timestamp will be provided as the action `data`. If you wish to have an action that continuously updates the `state` and rerenders inside of `requestAnimationFrame` (such as for a game), remember to include another `frame` effect in your return.
 
 Example:
-
-```js
-import { withEffects, frame } from "hyperapp-effects"
-
-withEffects(app)({
-  actions: {
-    foo: () => frame("spawn", { character: "goomba" }),
-    spawn: () => data => {
-      // This action is running inside requestAnimationFrame
-      // data will have { time: xxxx, character: "goomba" }
-    }
-  }
-}).foo()
-```
-
-If you wish to have an action that continuously updates the `state` and rerenders inside of `requestAnimationFrame` (such as for a game), remember to include another `frame` effect in your return:
 
 ```js
 import { withEffects, action, frame } from "hyperapp-effects"
@@ -222,10 +204,10 @@ withEffects(app)({
 ### `time`
 
 ```js
-time = function(name: string, data?: object): EffectTuple
+time = function(name: string): EffectTuple
 ```
 
-Describes an effect that will provide the current timestamp to an action using [`performance.now`](https://developer.mozilla.org/en-US/docs/Web/API/Performance/now), optionally with a `data` object. The timestamp will be provided as the `time` property on the action `data`.
+Describes an effect that will provide the current timestamp to an action using [`performance.now`](https://developer.mozilla.org/en-US/docs/Web/API/Performance/now). The timestamp will be provided as the action `data`.
 
 Example:
 
@@ -234,9 +216,9 @@ import { withEffects, time } from "hyperapp-effects"
 
 withEffects(app)({
   actions: {
-    foo: () => time("bar", { some: "data" }),
-    bar: () => data => {
-      // data will have { time: xxxx, some: "data" }
+    foo: () => time("bar"),
+    bar: () => timestamp => {
+      // use timestamp
     }
   }
 }).foo()
@@ -330,6 +312,27 @@ withEffects(app)({
   }
 }).login()
 ```
+
+### `event`
+
+Describes an effect that will capture event data when attached to a handler in your `view`. The originally fired event will be provided as the action `data`.
+
+```js
+import { withEffects, event } from "hyperapp-effects"
+
+withEffects(app)({
+  actions: {
+    click: () => clickEvent => {
+      // clickEvent has the props of the client event
+    }
+  },
+  view: () => h("button", {
+    onclick: event("click")
+  })
+})
+```
+
+It's recommended to only use `event` and `action` effects in your `view`, and all other effects from inside the actions called by these.
 
 ## License
 

--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,7 @@ export function withEffects(app) {
     if (props.view) {
       var originalView = props.view
       props.view = function(state, actions) {
-        var nextVdom = originalView.apply(null, arguments)
+        var nextVdom = originalView(state, actions)
         patchVdomEffects(actions, nextVdom)
         return nextVdom
       }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,4 +1,4 @@
-import { app } from "hyperapp"
+import { h, app } from "hyperapp"
 import { withEffects, action, frame, delay, time, log, http } from "../src"
 
 test("without actions", done =>
@@ -241,4 +241,50 @@ test("http post json", done => {
     }
   }).foo()
   delete global.fetch
+})
+
+test("action effects with data in view", done => {
+  document.body.innerHTML = ""
+  withEffects(app)({
+    actions: {
+      foo: () => data => {
+        expect(data).toEqual({ event: { button: 0 } })
+        done()
+      }
+    },
+    view: () =>
+      h(
+        "main",
+        {
+          oncreate: () => {
+            const buttonElement = document.body.firstChild.lastChild
+            buttonElement.onclick({ button: 0 })
+          }
+        },
+        h("button", { onclick: action("foo") })
+      )
+  })
+})
+
+test("action effects in view with data", done => {
+  document.body.innerHTML = ""
+  withEffects(app)({
+    actions: {
+      foo: () => data => {
+        expect(data).toEqual({ event: { button: 0 }, some: "data" })
+        done()
+      }
+    },
+    view: () =>
+      h(
+        "main",
+        {
+          oncreate: () => {
+            const buttonElement = document.body.firstChild.lastChild
+            buttonElement.onclick({ button: 0 })
+          }
+        },
+        h("button", { onclick: action("foo", { some: "data" }) })
+      )
+  })
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -252,21 +252,31 @@ test("http post json", done => {
 test("action effects in view", done => {
   document.body.innerHTML = ""
   withEffects(app)({
+    state: {
+      message: "hello"
+    },
     actions: {
       foo: () => data => {
         expect(data).toEqual({ some: "data" })
         done()
       }
     },
-    view: () =>
+    view: ({ message }, actions) =>
       h(
         "main",
         {
           oncreate: () => {
+            expect(actions).toEqual({
+              foo: expect.any(Function)
+            })
+            expect(document.body.innerHTML).toBe(
+              "<main><h1>hello</h1><button></button></main>"
+            )
             const buttonElement = document.body.firstChild.lastChild
             buttonElement.onclick({ button: 0 })
           }
         },
+        h("h1", {}, message),
         h("button", { onclick: action("foo", { some: "data" }) })
       )
   })
@@ -275,21 +285,31 @@ test("action effects in view", done => {
 test("event effects in view", done => {
   document.body.innerHTML = ""
   withEffects(app)({
+    state: {
+      message: "hello"
+    },
     actions: {
       foo: () => data => {
         expect(data).toEqual({ button: 0 })
         done()
       }
     },
-    view: () =>
+    view: ({ message }, actions) =>
       h(
         "main",
         {
           oncreate: () => {
+            expect(actions).toEqual({
+              foo: expect.any(Function)
+            })
+            expect(document.body.innerHTML).toBe(
+              "<main><h1>hello</h1><button></button></main>"
+            )
             const buttonElement = document.body.firstChild.lastChild
             buttonElement.onclick({ button: 0 })
           }
         },
+        h("h1", {}, message),
         h("button", { onclick: event("foo") })
       )
   })
@@ -298,6 +318,9 @@ test("event effects in view", done => {
 test("combined action and event effects in view", done => {
   document.body.innerHTML = ""
   withEffects(app)({
+    state: {
+      message: "hello"
+    },
     actions: {
       foo: () => data => {
         expect(data).toEqual({ button: 0 })
@@ -307,15 +330,23 @@ test("combined action and event effects in view", done => {
         done()
       }
     },
-    view: () =>
+    view: ({ message }, actions) =>
       h(
         "main",
         {
           oncreate: () => {
+            expect(actions).toEqual({
+              foo: expect.any(Function),
+              bar: expect.any(Function)
+            })
+            expect(document.body.innerHTML).toBe(
+              "<main><h1>hello</h1><button></button></main>"
+            )
             const buttonElement = document.body.firstChild.lastChild
             buttonElement.onclick({ button: 0 })
           }
         },
+        h("h1", {}, message),
         h("button", {
           onclick: [event("foo"), action("bar", { some: "data" })]
         })


### PR DESCRIPTION
This extra piece of the pie 🍰  allows writing your `view` without side effects, potentially building your entire app out of pure functions! 🎉 

Custom data props were removed from all effects that already provide some sort of data instead of trying to merge the two: `frame` and `time`.

Also a new effect was added: `event`, which provides event data when used as an event handler on a VNode.