### PR TITLE
Error handling for http request

### DIFF
--- a/src/immutable.js
+++ b/src/immutable.js
@@ -1,9 +1,9 @@
 export function removeKeysFromObject(object, keys) {
-  var cpy = {}
+  var copy = {}
   Object.keys(object)
-    .filter(k => keys.indexOf(k) === -1)
-    .forEach(k => {
-      cpy[k] = object[k]
+    .filter(key => keys.indexOf(key) === -1)
+    .forEach(key => {
+      copy[key] = object[key]
     })
-  return cpy
+  return copy
 }

--- a/src/immutable.js
+++ b/src/immutable.js
@@ -1,5 +1,9 @@
 export function removeKeysFromObject(object, keys) {
-  return Object.keys(object)
+  var cpy = {}
+  Object.keys(object)
     .filter(k => keys.indexOf(k) === -1)
-    .reduce((acc, k) => Object.assign({}, acc, { [k]: object[k] }), {})
+    .forEach(k => {
+      cpy[k] = object[k]
+    })
+  return cpy
 }

--- a/src/immutable.js
+++ b/src/immutable.js
@@ -1,5 +1,5 @@
 export function removeKeysFromObject(object, keys) {
   return Object.entries(object)
     .filter(([k, v]) => keys.indexOf(k) === -1)
-    .reduce((acc, [k, v]) => ({ ...acc, [k]: v }), {})
+    .reduce((acc, [k, v]) => Object.assign({}, acc, { [k]: v }), {})
 }

--- a/src/immutable.js
+++ b/src/immutable.js
@@ -1,0 +1,5 @@
+export function removeKeysFromObject(object, keys) {
+  return Object.entries(object)
+    .filter(([k, v]) => keys.indexOf(k) === -1)
+    .reduce((acc, [k, v]) => ({ ...acc, [k]: v }), {})
+}

--- a/src/immutable.js
+++ b/src/immutable.js
@@ -1,5 +1,5 @@
 export function removeKeysFromObject(object, keys) {
-  return Object.entries(object)
-    .filter(([k, v]) => keys.indexOf(k) === -1)
-    .reduce((acc, [k, v]) => Object.assign({}, acc, { [k]: v }), {})
+  return Object.keys(object)
+    .filter(k => keys.indexOf(k) === -1)
+    .reduce((acc, k) => Object.assign({}, acc, { [k]: object[k] }), {})
 }

--- a/src/makeDefaultEffects.js
+++ b/src/makeDefaultEffects.js
@@ -47,6 +47,12 @@ export default function makeDefaultEffects() {
     }
     fetch(props.url, props.options)
       .then(function(response) {
+        if (!response.ok) {
+          throw response
+        }
+        return response
+      })
+      .then(function(response) {
         return response[props.options.response]()
       })
       .then(function(result) {

--- a/src/makeDefaultEffects.js
+++ b/src/makeDefaultEffects.js
@@ -44,7 +44,10 @@ export default function makeDefaultEffects() {
     props.options = props.options || {}
     props.options.response = props.options.response || "json"
     props.options.error = props.options.error || props.action
-    var fetchPayload = removeKeysFromObject(props.options, ["json", "error"])
+    var fetchPayload = removeKeysFromObject(props.options, [
+      "response",
+      "error"
+    ])
     fetch(props.url, fetchPayload)
       .then(function(response) {
         if (!response.ok) {

--- a/src/makeDefaultEffects.js
+++ b/src/makeDefaultEffects.js
@@ -11,6 +11,8 @@ import {
   RANDOM
 } from "./effectTypes"
 
+import { removeKeysFromObject } from "./immutable.js"
+
 export default function makeDefaultEffects() {
   var effects = {}
 
@@ -41,11 +43,9 @@ export default function makeDefaultEffects() {
   effects[HTTP] = function(props, getAction) {
     props.options = props.options || {}
     props.options.response = props.options.response || "json"
-    var errorAction = props.options.error || props.action
-    if (props.options.error) {
-      delete props.options.error
-    }
-    fetch(props.url, props.options)
+    props.options.error = props.options.error || props.action
+    var fetchPayload = removeKeysFromObject(props.options, ["json", "error"])
+    fetch(props.url, fetchPayload)
       .then(function(response) {
         if (!response.ok) {
           throw response
@@ -59,7 +59,7 @@ export default function makeDefaultEffects() {
         getAction(props.action)(result)
       })
       .catch(function(err) {
-        getAction(errorAction)(err)
+        getAction(props.options.error)(err)
       })
   }
 

--- a/src/withEffects.js
+++ b/src/withEffects.js
@@ -62,10 +62,10 @@ function runIfEffect(actions, currentEvent, maybeEffect) {
       case HTTP:
         props.options = props.options || {}
         props.options.response = props.options.response || "json"
-        var errorAction = props.options.error || props.action;
+        var errorAction = props.options.error || props.action
         if (props.options.error) {
           delete props.options.error
-        } 
+        }
         fetch(props.url, props.options)
           .then(function(response) {
             return response[props.options.response]()
@@ -73,7 +73,7 @@ function runIfEffect(actions, currentEvent, maybeEffect) {
           .then(function(result) {
             getAction(actions, props.action)(result)
           })
-          .catch(function (err) {
+          .catch(function(err) {
             getAction(actions, errorAction)(err)
           })
         break

--- a/src/withEffects.js
+++ b/src/withEffects.js
@@ -69,6 +69,9 @@ function runIfEffect(actions, currentEvent, maybeEffect) {
           .then(function(result) {
             getAction(actions, props.action)(result)
           })
+          .catch(function (err) {
+            getAction(actions, props.options.error)(err)
+          })
         break
       case EVENT:
         getAction(actions, props.action)(currentEvent)

--- a/src/withEffects.js
+++ b/src/withEffects.js
@@ -64,8 +64,8 @@ function runIfEffect(actions, currentEvent, maybeEffect) {
         props.options.response = props.options.response || "json"
         var errorAction = props.options.error || props.action;
         if (props.options.error) {
-          delete props.option.error
-        }
+          delete props.options.error
+        } 
         fetch(props.url, props.options)
           .then(function(response) {
             return response[props.options.response]()

--- a/src/withEffects.js
+++ b/src/withEffects.js
@@ -62,6 +62,10 @@ function runIfEffect(actions, currentEvent, maybeEffect) {
       case HTTP:
         props.options = props.options || {}
         props.options.response = props.options.response || "json"
+        var errorAction = props.options.error || props.action;
+        if (props.options.error) {
+          delete props.option.error
+        }
         fetch(props.url, props.options)
           .then(function(response) {
             return response[props.options.response]()
@@ -70,7 +74,7 @@ function runIfEffect(actions, currentEvent, maybeEffect) {
             getAction(actions, props.action)(result)
           })
           .catch(function (err) {
-            getAction(actions, props.options.error)(err)
+            getAction(actions, errorAction)(err)
           })
         break
       case EVENT:

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -227,9 +227,7 @@ describe("withEffects", () => {
         const testUrl = "https://example.com"
         global.fetch = (url, options) => {
           expect(url).toBe(testUrl)
-          expect(options).toEqual({
-            response: "json"
-          })
+          expect(options).toEqual({})
           return Promise.resolve({
             ok: true,
             json: () => Promise.resolve({ response: "data" })
@@ -255,9 +253,7 @@ describe("withEffects", () => {
         const testUrl = "https://example.com/hello"
         global.fetch = (url, options) => {
           expect(url).toBe(testUrl)
-          expect(options).toEqual({
-            response: "text"
-          })
+          expect(options).toEqual({})
           return Promise.resolve({
             ok: true,
             text: () => Promise.resolve("hello world")
@@ -286,8 +282,7 @@ describe("withEffects", () => {
             body: {
               user: "username",
               pass: "password"
-            },
-            response: "json"
+            }
           })
           return Promise.resolve({
             ok: true,
@@ -317,9 +312,7 @@ describe("withEffects", () => {
         const error = new Error("Failed")
         global.fetch = (url, options) => {
           expect(url).toBe(testUrl)
-          expect(options).toEqual({
-            response: "text"
-          })
+          expect(options).toEqual({})
           return Promise.reject(error)
         }
         withEffects(app)(
@@ -350,9 +343,7 @@ describe("withEffects", () => {
         const error = new Error("Failed")
         global.fetch = (url, options) => {
           expect(url).toBe(testUrl)
-          expect(options).toEqual({
-            response: "text"
-          })
+          expect(options).toEqual({})
           return Promise.reject(error)
         }
         withEffects(app)(
@@ -377,9 +368,7 @@ describe("withEffects", () => {
         }
         global.fetch = (url, options) => {
           expect(url).toBe(testUrl)
-          expect(options).toEqual({
-            response: "text"
-          })
+          expect(options).toEqual({})
           return Promise.resolve(response)
         }
         withEffects(app)(

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -231,6 +231,7 @@ describe("withEffects", () => {
             response: "json"
           })
           return Promise.resolve({
+            ok: true,
             json: () => Promise.resolve({ response: "data" })
           })
         }
@@ -258,6 +259,7 @@ describe("withEffects", () => {
             response: "text"
           })
           return Promise.resolve({
+            ok: true,
             text: () => Promise.resolve("hello world")
           })
         }
@@ -288,6 +290,7 @@ describe("withEffects", () => {
             response: "json"
           })
           return Promise.resolve({
+            ok: true,
             json: () => Promise.resolve({ result: "authenticated" })
           })
         }
@@ -360,6 +363,33 @@ describe("withEffects", () => {
             bar: {
               baz: data => {
                 expect(data).toBe(error)
+                done()
+              }
+            }
+          }
+        ).foo()
+        delete global.fetch
+      })
+      it("should call default action on error when response is not OK", done => {
+        const testUrl = "https://example.com/hello"
+        const response = {
+          ok: false
+        }
+        global.fetch = (url, options) => {
+          expect(url).toBe(testUrl)
+          expect(options).toEqual({
+            response: "text"
+          })
+          return Promise.resolve(response)
+        }
+        withEffects(app)(
+          {},
+          {
+            foo: () => http(testUrl, "bar.baz", { response: "text" }),
+
+            bar: {
+              baz: data => {
+                expect(data).toBe(response)
                 done()
               }
             }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -275,7 +275,7 @@ test("http post json", done => {
 
 test("http get text fail", done => {
   const testUrl = "https://example.com/hello"
-  const error = new Error('Failed');
+  const error = new Error("Failed")
   global.fetch = (url, options) => {
     expect(url).toBe(testUrl)
     expect(options).toEqual({
@@ -286,16 +286,20 @@ test("http get text fail", done => {
   withEffects(app)(
     {},
     {
-      foo: () => http(testUrl, "bar.baz", { response: "text", error: "fizz.errorHandler" }),
+      foo: () =>
+        http(testUrl, "bar.baz", {
+          response: "text",
+          error: "fizz.errorHandler"
+        }),
       fizz: {
-        errorHandler: (err) => {
-          expect(err).toBe(error);
+        errorHandler: err => {
+          expect(err).toBe(error)
           done()
         }
       },
       bar: {
         baz: data => {
-          done.fail(new Error('Should not be called'))
+          done.fail(new Error("Should not be called"))
         }
       }
     }
@@ -305,7 +309,7 @@ test("http get text fail", done => {
 
 test("http get text fail with no handler defined", done => {
   const testUrl = "https://example.com/hello"
-  const error = new Error('Failed');
+  const error = new Error("Failed")
   global.fetch = (url, options) => {
     expect(url).toBe(testUrl)
     expect(options).toEqual({

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -273,6 +273,62 @@ test("http post json", done => {
   delete global.fetch
 })
 
+test("http get text fail", done => {
+  const testUrl = "https://example.com/hello"
+  const error = new Error('Failed');
+  global.fetch = (url, options) => {
+    expect(url).toBe(testUrl)
+    expect(options).toEqual({
+      response: "text"
+    })
+    return Promise.reject(error)
+  }
+  withEffects(app)(
+    {},
+    {
+      foo: () => http(testUrl, "bar.baz", { response: "text", error: "fizz.errorHandler" }),
+      fizz: {
+        errorHandler: (err) => {
+          expect(err).toBe(error);
+          done()
+        }
+      },
+      bar: {
+        baz: data => {
+          done.fail(new Error('Should not be called'))
+        }
+      }
+    }
+  ).foo()
+  delete global.fetch
+})
+
+test("http get text fail with no handler defined", done => {
+  const testUrl = "https://example.com/hello"
+  const error = new Error('Failed');
+  global.fetch = (url, options) => {
+    expect(url).toBe(testUrl)
+    expect(options).toEqual({
+      response: "text"
+    })
+    return Promise.reject(error)
+  }
+  withEffects(app)(
+    {},
+    {
+      foo: () => http(testUrl, "bar.baz", { response: "text" }),
+
+      bar: {
+        baz: data => {
+          expect(data).toBe(error)
+          done()
+        }
+      }
+    }
+  ).foo()
+  delete global.fetch
+})
+
 test("action effects in view", done => {
   document.body.innerHTML = ""
   withEffects(app)(


### PR DESCRIPTION
Catch an http failure. see #15 
The "error action" is specified into `options.error`. No breaking change.